### PR TITLE
Add unsupported page helper

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -26,7 +26,9 @@ export default defineBackground(() => {
   async function updateBadge(text: string, color: string, tabId?: number) {
     try {
       await browser.action.setBadgeText({ text, tabId });
-      await browser.action.setBadgeBackgroundColor({ color, tabId });
+      const colorSpec: string | [number, number, number, number] =
+        color === 'transparent' ? [0, 0, 0, 0] : color;
+      await browser.action.setBadgeBackgroundColor({ color: colorSpec as any, tabId });
     } catch (error) {
       console.error('Failed to update badge:', error);
     }

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import './App.css';
 import { FiDownload, FiRefreshCw, FiMousePointer, FiX } from 'react-icons/fi';
 import { RiGridLine } from 'react-icons/ri';
+import { isSupportedTab } from './utils';
 
 interface TableMeta {
   id: string;
@@ -130,7 +131,7 @@ function App() {
   const handleSelectionMode = async () => {
     try {
       const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-      if (!tab.id) {
+      if (!isSupportedTab(tab)) {
         setError(browser.i18n.getMessage('unableAccess'));
         return;
       }
@@ -154,7 +155,7 @@ function App() {
     try {
       setExportingId(tableId);
       const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-      if (!tab.id) {
+      if (!isSupportedTab(tab)) {
         throw new Error(browser.i18n.getMessage('unableAccess'));
       }
 
@@ -175,7 +176,7 @@ function App() {
   const handleHighlight = async (tableId: string) => {
     try {
       const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-      if (!tab.id) {
+      if (!isSupportedTab(tab)) {
         return;
       }
 

--- a/entrypoints/popup/utils.ts
+++ b/entrypoints/popup/utils.ts
@@ -1,0 +1,11 @@
+export function isSupportedTab(tab: browser.tabs.Tab | undefined): boolean {
+  if (!tab || !tab.id || !tab.url) {
+    return false;
+  }
+  const unsupportedPrefixes = [
+    'chrome://',
+    'chrome-extension://',
+    'chrome-devtools://'
+  ];
+  return !unsupportedPrefixes.some(prefix => tab.url!.startsWith(prefix));
+}


### PR DESCRIPTION
## Summary
- create `isSupportedTab` helper for checking if active tab is usable
- apply helper when toggling selection mode, exporting or highlighting tables

## Testing
- `bun run build`
- `bun test` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68514258d18083309dd7011970562e07